### PR TITLE
Homing override fixes

### DIFF
--- a/Firmware/Voron_Trident_SKR14_EXPMOT.cfg
+++ b/Firmware/Voron_Trident_SKR14_EXPMOT.cfg
@@ -387,7 +387,7 @@ gcode:
    G0 Z5 F600
    G28 X Y
    ##	XY Location of the Z Endstop Switch
-   ##	Update X0 and Y0 to your values (such as X157, Y305) after going through
+   ##	Update X and Y to your values (such as X157, Y305) after going through
    ##	Z Endstop Pin Location Definition step.
    G0 X-10 Y-10 F3600 
    

--- a/Firmware/Voron_Trident_SKR14_EXPMOT.cfg
+++ b/Firmware/Voron_Trident_SKR14_EXPMOT.cfg
@@ -389,7 +389,7 @@ gcode:
    ##	XY Location of the Z Endstop Switch
    ##	Update X0 and Y0 to your values (such as X157, Y305) after going through
    ##	Z Endstop Pin Location Definition step.
-   G0 X0 Y0 F3600 
+   G0 X-10 Y-10 F3600 
    
    G28 Z
    G0 Z10 F1800

--- a/Firmware/Voron_Trident_SKR_1.3.cfg
+++ b/Firmware/Voron_Trident_SKR_1.3.cfg
@@ -432,7 +432,7 @@ gcode:
    ##	XY Location of the Z Endstop Switch
    ##	Update X0 and Y0 to your values (such as X157, Y305) after going through
    ##	Z Endstop Pin Location Definition step.
-   G0 X0 Y0 F3600 
+   G0 X-10 Y-10 F3600 
    
    G28 Z
    G0 Z10 F1800

--- a/Firmware/Voron_Trident_SKR_1.3.cfg
+++ b/Firmware/Voron_Trident_SKR_1.3.cfg
@@ -430,7 +430,7 @@ gcode:
    G0 Z5 F600
    G28 X Y
    ##	XY Location of the Z Endstop Switch
-   ##	Update X0 and Y0 to your values (such as X157, Y305) after going through
+   ##	Update X and Y to your values (such as X157, Y305) after going through
    ##	Z Endstop Pin Location Definition step.
    G0 X-10 Y-10 F3600 
    


### PR DESCRIPTION
Update homing_override default position to -10,-10 to cause error when not updated properly by the end user.
