### PR TITLE
Octopus config for Trident

### DIFF
--- a/Firmware/Octopus/Trident_Octopus_Config.cfg
+++ b/Firmware/Octopus/Trident_Octopus_Config.cfg
@@ -1,0 +1,552 @@
+# This file contains common pin mappings for the BigTreeTech Octopus V1.
+# To use this config, the firmware should be compiled for the STM32F446 with a "32KiB bootloader"
+# Enable "extra low-level configuration options" and select the "12MHz crystal" as clock reference
+
+# after running "make", copy the generated "klipper/out/klipper.bin" file to a
+# file named "firmware.bin" on an SD card and then restart the OctoPus with that SD card.
+
+# See docs/Config_Reference.md for a description of parameters.
+
+## Voron Design Trident 250/300/350mm BigTreeTech OctoPus V1 TMC2209 UART config
+
+## *** THINGS TO CHANGE/CHECK: ***
+## MCU paths                            [mcu] section
+## Thermistor types                     [extruder] and [heater_bed] sections - See 'sensor types' list at end of file
+## Z Endstop Switch location            [safe_z_home] section
+## Z Endstop Switch  offset for Z0      [stepper_z] section
+## PID tune                             [extruder] and [heater_bed] sections
+## Probe pin                            [probe] section
+## Fine tune E steps                    [extruder] section
+
+[mcu]
+##  Obtain definition by "ls -l /dev/serial/by-id/" then unplug to verify
+##--------------------------------------------------------------------
+serial: /dev/serial/by-id/{REPLACE WITH YOUR SERIAL}
+restart_method: command
+##--------------------------------------------------------------------
+
+[printer]
+kinematics: corexy
+max_velocity: 300  
+max_accel: 3000             #Max 4000
+max_z_velocity: 15          #Max 15 for 12V TMC Drivers, can increase for 24V
+max_z_accel: 350
+square_corner_velocity: 5.0
+
+#####################################################################
+#   X/Y Stepper Settings
+#####################################################################
+
+##  B Stepper - Left
+##  Connected to MOTOR_0
+##  Endstop connected to DIAG_0
+[stepper_x]
+step_pin: PF13
+dir_pin: !PF12
+enable_pin: !PF14
+rotation_distance: 40
+microsteps: 32
+full_steps_per_rotation:200  #set to 400 for 0.9 degree stepper
+endstop_pin: PG6
+position_min: 0
+##--------------------------------------------------------------------
+
+##  Uncomment below for 250mm build
+#position_endstop: 250
+#position_max: 250
+
+##  Uncomment for 300mm build
+#position_endstop: 300
+#position_max: 300
+
+##  Uncomment for 350mm build
+#position_endstop: 350
+#position_max: 350
+
+##--------------------------------------------------------------------
+homing_speed: 25   #Max 100
+homing_retract_dist: 5
+homing_positive_dir: true
+
+##  Make sure to update below for your relevant driver (2208 or 2209)
+[tmc2209 stepper_x]
+uart_pin: PC4
+interpolate: False
+run_current: 0.8
+hold_current: 0.8
+sense_resistor: 0.110
+stealthchop_threshold: 0
+
+##  A Stepper - Right
+##  Connected to MOTOR_1
+##  Endstop connected to DIAG_1
+[stepper_y]
+step_pin: PG0
+dir_pin: !PG1
+enable_pin: !PF15
+rotation_distance: 40
+microsteps: 32
+full_steps_per_rotation:200  #set to 400 for 0.9 degree stepper
+endstop_pin: PG9
+position_min: 0
+##--------------------------------------------------------------------
+
+##  Uncomment for 250mm build
+#position_endstop: 250
+#position_max: 250
+
+##  Uncomment for 300mm build
+#position_endstop: 300
+#position_max: 300
+
+##  Uncomment for 350mm build
+#position_endstop: 350
+#position_max: 350
+
+##--------------------------------------------------------------------
+homing_speed: 25  #Max 100
+homing_retract_dist: 5
+homing_positive_dir: true
+
+##  Make sure to update below for your relevant driver (2208 or 2209)
+[tmc2209 stepper_y]
+uart_pin: PD11
+interpolate: False
+run_current: 0.8
+hold_current: 0.8
+sense_resistor: 0.110
+stealthchop_threshold: 0
+ 
+#####################################################################
+#   Z Stepper Settings
+#####################################################################
+
+## Z0 Stepper - Front Left
+##  Connected to MOTOR_2
+##  Endstop connected to DIAG_2
+[stepper_z]
+step_pin: PF11
+dir_pin: PG3
+enable_pin: !PG5
+##T8x4 Lead Screws.  One rotation moves the bed 4mm 
+##Change according to integrated steppers purchased
+rotation_distance: 4
+microsteps: 32
+endstop_pin: PG10
+##  Z-position of nozzle (in mm) to z-endstop trigger point relative to print surface (Z0)
+##  (+) value = endstop above Z0, (-) value = endstop below
+##  Increasing position_endstop brings nozzle closer to the bed
+##  After you run Z_ENDSTOP_CALIBRATE, position_endstop will be stored at the very end of your config
+position_endstop: -0.5
+## All builds use same Max Z
+position_max: 250
+position_max: 250
+position_min: -2.5
+homing_speed: 35.0
+second_homing_speed: 3
+homing_retract_dist: 3
+
+##  Make sure to update below for your relevant driver (2208 or 2209)
+[tmc2209 stepper_z]
+uart_pin: PC6
+interpolate: False
+run_current: 0.8
+hold_current: 0.8
+sense_resistor: 0.110
+stealthchop_threshold: 0
+
+##  Z1 Stepper - Rear Center
+##  Connected to MOTOR_3
+[stepper_z1]
+step_pin: PG4
+dir_pin: PC1
+enable_pin: !PA0
+##T8x4 Lead Screws.  One rotation moves the bed 4mm 
+##Change according to integrated steppers purchased
+rotation_distance: 4
+microsteps: 32
+microsteps: 32
+
+##  Make sure to update below for your relevant driver (2208 or 2209)
+[tmc2209 stepper_z1]
+uart_pin: PC7
+interpolate: False
+run_current: 0.8
+hold_current: 0.8
+sense_resistor: 0.110
+stealthchop_threshold: 0
+
+##  Z2 Stepper - Front Right
+##  Connected to MOTOR_4
+[stepper_z2]
+step_pin: PF9
+dir_pin: !PF10
+enable_pin: !PG2
+##T8x4 Lead Screws.  One rotation moves the bed 4mm 
+##Change according to integrated steppers purchased
+rotation_distance: 4
+microsteps: 32
+microsteps: 32
+
+##  Make sure to update below for your relevant driver (2208 or 2209)
+[tmc2209 stepper_z2]
+uart_pin: PF2
+interpolate: False
+run_current: 0.8
+hold_current: 0.8
+sense_resistor: 0.110
+stealthchop_threshold: 0
+
+
+#####################################################################
+#   Extruder
+#####################################################################
+
+#   Connected to MOTOR_6
+#   Heater - HE0
+#   Thermistor - T0
+[extruder]
+step_pin: PE2
+dir_pin: PE3
+enable_pin: !PD4
+##  Update value below when you perform extruder calibration
+##  If you ask for 100mm of filament, but in reality it is 98mm:
+##  rotation_distance = <previous_rotation_distance> * <actual_extrude_distance> / 100
+##  22.6789511 is a good starting point
+rotation_distance: 22.6789511   #Bondtech 5mm Drive Gears
+##  Update Gear Ratio depending on your Extruder Type
+##  Use 50:17 for Afterburner/Clockwork (BMG Gear Ratio)
+##  Use 80:20 for M4, M3.1
+gear_ratio: 50:17               #BMG Gear Ratio
+microsteps: 32
+full_steps_per_rotation: 200    #200 for 1.8 degree, 400 for 0.9 degree
+nozzle_diameter: 0.400
+filament_diameter: 1.75
+heater_pin: PA2
+##  Validate the following thermistor type to make sure it is correct (see bottom of file for additional options)
+# sensor_type: ATC Semitec 104GT-2
+sensor_pin: PF4
+min_temp: 10
+max_temp: 270
+max_power: 1.0
+min_extrude_temp: 170
+control = pid
+pid_kp = 26.213
+pid_ki = 1.304
+pid_kd = 131.721
+##  Try to keep pressure_advance below 1.0
+pressure_advance: 0.05
+##  Default is 0.040, leave stock
+pressure_advance_smooth_time: 0.040
+
+##  E0 on MOTOR6
+##  Make sure to update below for your relevant driver (2208 or 2209)
+[tmc2209 extruder]
+uart_pin: PE1
+interpolate: false
+run_current: 0.5
+hold_current: 0.4
+sense_resistor: 0.110
+stealthchop_threshold: 0
+
+
+#####################################################################
+#   Bed Heater
+#####################################################################
+
+[heater_bed]
+##  SSR Pin - HE1
+##  Thermistor - TB
+heater_pin: PA3
+##  Validate the following thermistor type to make sure it is correct (see bottom of file for additional options)
+# sensor_type: NTC 100K MGB18-104F39050L32
+sensor_pin: PF3
+##  Adjust Max Power so your heater doesn't warp your bed. Rule of thumb is 0.4 watts / cm^2 .
+max_power: 0.6
+min_temp: 0
+max_temp: 120
+control: pid
+pid_kp: 58.437
+pid_ki: 2.347
+pid_kd: 363.769
+
+#####################################################################
+#   Probe
+#####################################################################
+
+[probe]
+##  Inductive Probe
+##  This probe is not used for Z height, only Quad Gantry Leveling
+
+# Select the probe port by type:
+## For the PROBE port. Will not work with Diode. May need pull-up resistor from signal to 24V.
+# pin: ~!PB7
+## For the DIAG_7 port. NEEDS BAT85 DIODE! Change to !PG15 if probe is NO.
+# pin: PG15
+## For Octopus Pro Probe port; NPN and PNP proximity switch types can be set by jumper
+# pin: ^PC5
+
+#--------------------------------------------------------------------
+
+x_offset: 0
+y_offset: 25.0
+z_offset: 0
+speed: 10.0
+samples: 3
+samples_result: median
+sample_retract_dist: 3.0
+samples_tolerance: 0.006
+samples_tolerance_retries: 3
+
+#####################################################################
+#   Fan Control
+#####################################################################
+
+[fan]
+##  Print Cooling Fan - FAN0
+pin: PA8
+kick_start_time: 0.5
+##  Depending on your fan, you may need to increase this value
+##  if your fan will not start. Can change cycle_time (increase)
+##  if your fan is not able to slow down effectively
+off_below: 0.10
+
+[heater_fan hotend_fan]
+##  Hotend Fan - FAN1
+pin: PE5
+max_power: 1.0
+kick_start_time: 0.5
+heater: extruder
+heater_temp: 50.0
+##  If you are experiencing back flow, you can reduce fan_speed
+#fan_speed: 1.0
+
+[controller_fan controller_fan]
+##  Controller fan - FAN2
+pin: PD12
+kick_start_time: 0.5
+heater: heater_bed
+
+#[heater_fan exhaust_fan]
+##  Exhaust fan - FAN3
+#pin: PD13
+#max_power: 1.0
+#shutdown_speed: 0.0
+#kick_start_time: 5.0
+#heater: heater_bed
+#heater_temp: 60
+#fan_speed: 1.0
+
+#####################################################################
+#   LED Control
+#####################################################################
+
+#[output_pin caselight]
+# Chamber Lighting - HE2 Connector (Optional)
+#pin: PB10
+#pwm:true
+#shutdown_value: 0
+#value:1
+#cycle_time: 0.01
+
+#####################################################################
+#   Homing and Gantry Adjustment Routines
+#####################################################################
+
+[idle_timeout]
+timeout: 1800
+
+[safe_z_home]
+##  XY Location of the Z Endstop Switch
+##  Update -10,-10 to the XY coordinates of your endstop pin 
+##  (such as 157,305) after going through Z Endstop Pin
+##  Location Definition step.
+home_xy_position:-10,-10
+speed:100
+z_hop:10
+
+[quad_gantry_level]
+##  Use QUAD_GANTRY_LEVEL to level a gantry.
+##  Min & Max gantry corners - measure from nozzle at MIN (0,0) and 
+##  MAX (250, 250), (300,300), or (350,350) depending on your printer size
+##  to respective belt positions
+
+#--------------------------------------------------------------------
+##  Gantry Corners for 250mm Build
+##  Uncomment for 250mm build
+#gantry_corners:
+#   -60,-10
+#   310, 320
+##  Probe points
+#points:
+#   50,25
+#   50,175
+#   200,175
+#   200,25
+    
+##  Gantry Corners for 300mm Build
+##  Uncomment for 300mm build
+#gantry_corners:
+#   -60,-10
+#   360,370
+##  Probe points
+#points:
+#   50,25
+#   50,225
+#   250,225
+#   250,25
+
+##  Gantry Corners for 350mm Build
+##  Uncomment for 350mm build
+#gantry_corners:
+#   -60,-10
+#   410,420
+##  Probe points
+#points:
+#   50,25
+#   50,275
+#   300,275
+#   300,25
+
+#--------------------------------------------------------------------
+speed: 100
+horizontal_move_z: 10
+retries: 5
+retry_tolerance: 0.0075
+max_adjust: 10
+
+########################################
+# EXP1 / EXP2 (display) pins
+########################################
+
+[board_pins]
+aliases:
+    # EXP1 header
+    EXP1_1=PE8, EXP1_2=PE7,
+    EXP1_3=PE9, EXP1_4=PE10,
+    EXP1_5=PE12, EXP1_6=PE13,    # Slot in the socket on this side
+    EXP1_7=PE14, EXP1_8=PE15,
+    EXP1_9=<GND>, EXP1_10=<5V>,
+
+    # EXP2 header
+    EXP2_1=PA6, EXP2_2=PA5,
+    EXP2_3=PB1, EXP2_4=PA4,
+    EXP2_5=PB2, EXP2_6=PA7,      # Slot in the socket on this side
+    EXP2_7=PC15, EXP2_8=<RST>,
+    EXP2_9=<GND>, EXP2_10=<5V>
+
+#####################################################################
+#   Displays
+#####################################################################
+
+##  Uncomment the display that you have
+#--------------------------------------------------------------------
+
+#[display]
+##  RepRapDiscount 128x64 Full Graphic Smart Controller
+#lcd_type: st7920
+#cs_pin: EXP1_4
+#sclk_pin: EXP1_5
+#sid_pin: EXP1_3
+#menu_timeout: 40
+#encoder_pins: ^EXP2_5, ^EXP2_3
+#click_pin: ^!EXP1_2
+
+#[output_pin beeper]
+#pin: EXP1_1
+
+#--------------------------------------------------------------------
+
+#[display]
+##  mini12864 LCD Display
+#lcd_type: uc1701
+#cs_pin: EXP1_3
+#a0_pin: EXP1_4
+#rst_pin: EXP1_5
+#encoder_pins: ^EXP2_5, ^EXP2_3
+#click_pin: ^!EXP1_2
+#contrast: 63
+#spi_software_miso_pin: EXP2_1
+#spi_software_mosi_pin: EXP2_6
+#spi_software_sclk_pin: EXP2_2
+
+#[neopixel btt_mini12864]
+##  To control Neopixel RGB in mini12864 display
+#pin: EXP1_6
+#chain_count: 3
+#initial_RED: 0.1
+#initial_GREEN: 0.5
+#initial_BLUE: 0.0
+#color_order: RGB
+
+##  Set RGB values on boot up for each Neopixel. 
+##  Index 1 = display, Index 2 and 3 = Knob
+#[delayed_gcode setdisplayneopixel]
+#initial_duration: 1
+#gcode:
+#        SET_LED LED=btt_mini12864 RED=1 GREEN=1 BLUE=1 INDEX=1 TRANSMIT=0
+#        SET_LED LED=btt_mini12864 RED=1 GREEN=0 BLUE=0 INDEX=2 TRANSMIT=0
+#        SET_LED LED=btt_mini12864 RED=1 GREEN=0 BLUE=0 INDEX=3 
+
+#--------------------------------------------------------------------
+
+
+#####################################################################
+#   Macros
+#####################################################################
+
+[gcode_macro PRINT_START]
+#   Use PRINT_START for the slicer starting script - PLEASE CUSTOMISE THE SCRIPT
+gcode:
+    M117 Homing...                 ; display message
+    G28
+    Z_TILT_ADJUST
+    G28
+
+    ##  Uncomment for for your size printer:
+    #--------------------------------------------------------------------
+    ##  Uncomment for 250mm build
+    #G0 X125 Y125 Z30 F3600
+
+    ##  Uncomment for 300 build
+    #G0 X150 Y150 Z30 F3600
+
+    ##  Uncomment for 350mm build
+    #G0 X175 Y175 Z30 F3600
+    #--------------------------------------------------------------------
+
+   
+
+[gcode_macro PRINT_END]
+#   Use PRINT_END for the slicer ending script - please customise for your slicer of choice
+gcode:
+    # safe anti-stringing move coords
+    {% set th = printer.toolhead %}
+    {% set x_safe = th.position.x + 20 * (1 if th.axis_maximum.x - th.position.x > 20 else -1) %}
+    {% set y_safe = th.position.y + 20 * (1 if th.axis_maximum.y - th.position.y > 20 else -1) %}
+    {% set z_safe = [th.position.z + 2, th.axis_maximum.z]|min %}
+    
+    SAVE_GCODE_STATE NAME=STATE_PRINT_END
+    
+    M400                           ; wait for buffer to clear
+    G92 E0                         ; zero the extruder
+    G1 E-2.0 F3600                 ; retract filament
+    
+    TURN_OFF_HEATERS
+    
+    G90                                      ; absolute positioning
+    G0 X{x_safe} Y{y_safe} Z{z_safe} F20000  ; move nozzle to remove stringing
+    G0 X{th.axis_maximum.x//2} Y{th.axis_maximum.y - 2} F3600  ; park nozzle at rear
+    M107                                     ; turn off fan
+    
+    BED_MESH_CLEAR
+    RESTORE_GCODE_STATE NAME=STATE_PRINT_END
+    
+##  Thermistor Types
+##   "EPCOS 100K B57560G104F"
+##   "ATC Semitec 104GT-2"
+##   "NTC 100K beta 3950"
+##   "Honeywell 100K 135-104LAG-J01"
+##   "NTC 100K MGB18-104F39050L32" (Keenovo Heater Pad)
+##   "AD595"
+##   "PT100 INA826"

--- a/Firmware/Octopus/Trident_Octopus_Config.cfg
+++ b/Firmware/Octopus/Trident_Octopus_Config.cfg
@@ -368,14 +368,14 @@ z_hop:10
 
 ##--------------------------------------------------------------------
 ## Uncomment below for 250mm build
-z_positions:
-    -50, 18
-    125, 298
-    300, 18
-points:
-    30, 5
-    125, 195
-    220, 5
+#z_positions:
+#    -50, 18
+#    125, 298
+#    300, 18
+#points:
+#    30, 5
+#    125, 195
+#    220, 5
 
 ## Uncomment below for 300mm build
 #z_positions:

--- a/Firmware/Octopus/Trident_Octopus_Config.cfg
+++ b/Firmware/Octopus/Trident_Octopus_Config.cfg
@@ -74,7 +74,6 @@ homing_positive_dir: true
 uart_pin: PC4
 interpolate: False
 run_current: 0.8
-hold_current: 0.8
 sense_resistor: 0.110
 stealthchop_threshold: 0
 
@@ -114,7 +113,6 @@ homing_positive_dir: true
 uart_pin: PD11
 interpolate: False
 run_current: 0.8
-hold_current: 0.8
 sense_resistor: 0.110
 stealthchop_threshold: 0
  
@@ -150,7 +148,6 @@ homing_retract_dist: 3
 uart_pin: PC6
 interpolate: False
 run_current: 0.6
-hold_current: 0.6
 sense_resistor: 0.110
 stealthchop_threshold: 0
 
@@ -169,7 +166,6 @@ microsteps: 32
 uart_pin: PC7
 interpolate: False
 run_current: 0.6
-hold_current: 0.6
 sense_resistor: 0.110
 stealthchop_threshold: 0
 
@@ -188,7 +184,6 @@ microsteps: 32
 uart_pin: PF2
 interpolate: False
 run_current: 0.6
-hold_current: 0.6
 sense_resistor: 0.110
 stealthchop_threshold: 0
 
@@ -241,7 +236,6 @@ pid_kd = 131.721
 uart_pin: PE1
 interpolate: false
 run_current: 0.5
-hold_current: 0.4
 sense_resistor: 0.110
 stealthchop_threshold: 0
 

--- a/Firmware/Octopus/Trident_Octopus_Config.cfg
+++ b/Firmware/Octopus/Trident_Octopus_Config.cfg
@@ -11,7 +11,7 @@
 
 ## *** THINGS TO CHANGE/CHECK: ***
 ## MCU paths                            [mcu] section
-## Thermistor types                     [extruder] and [heater_bed] sections - See 'sensor types' list at end of file
+## Thermistor types                     [extruder] and [heater_bed] sections
 ## Leadscrew Rotation Distance          [stepper_z], [stepper_z1], [stepper_z2]
 ## Z Endstop Switch location            [safe_z_home] section
 ## Z Endstop Switch  offset for Z0      [stepper_z] section
@@ -140,9 +140,8 @@ endstop_pin: PG10
 position_endstop: -0.5
 ## All builds use same Max Z
 position_max: 250
-position_max: 250
 position_min: -2.5
-homing_speed: 35.0
+homing_speed: 8.0 # Leadscrews are slower than 2.4, 10 is a recommended max.
 second_homing_speed: 3
 homing_retract_dist: 3
 
@@ -150,8 +149,8 @@ homing_retract_dist: 3
 [tmc2209 stepper_z]
 uart_pin: PC6
 interpolate: False
-run_current: 0.8
-hold_current: 0.8
+run_current: 0.6
+hold_current: 0.6
 sense_resistor: 0.110
 stealthchop_threshold: 0
 
@@ -169,8 +168,8 @@ microsteps: 32
 [tmc2209 stepper_z1]
 uart_pin: PC7
 interpolate: False
-run_current: 0.8
-hold_current: 0.8
+run_current: 0.6
+hold_current: 0.6
 sense_resistor: 0.110
 stealthchop_threshold: 0
 
@@ -188,8 +187,8 @@ microsteps: 32
 [tmc2209 stepper_z2]
 uart_pin: PF2
 interpolate: False
-run_current: 0.8
-hold_current: 0.8
+run_current: 0.6
+hold_current: 0.6
 sense_resistor: 0.110
 stealthchop_threshold: 0
 
@@ -232,9 +231,9 @@ pid_kp = 26.213
 pid_ki = 1.304
 pid_kd = 131.721
 ##  Try to keep pressure_advance below 1.0
-pressure_advance: 0.05
+# pressure_advance: 0.05
 ##  Default is 0.040, leave stock
-pressure_advance_smooth_time: 0.040
+# pressure_advance_smooth_time: 0.040
 
 ##  E0 on MOTOR6
 ##  Make sure to update below for your relevant driver (2208 or 2209)
@@ -363,55 +362,48 @@ home_xy_position:-10,-10
 speed:100
 z_hop:10
 
-[quad_gantry_level]
-##  Use QUAD_GANTRY_LEVEL to level a gantry.
-##  Min & Max gantry corners - measure from nozzle at MIN (0,0) and 
-##  MAX (250, 250), (300,300), or (350,350) depending on your printer size
-##  to respective belt positions
+[z_tilt]
+##  Use Z_TILT_ADJUST to level the bed .
+##  z_positions: Location of toolhead
 
-#--------------------------------------------------------------------
-##  Gantry Corners for 250mm Build
-##  Uncomment for 250mm build
-#gantry_corners:
-#   -60,-10
-#   310, 320
-##  Probe points
-#points:
-#   50,25
-#   50,175
-#   200,175
-#   200,25
-    
-##  Gantry Corners for 300mm Build
-##  Uncomment for 300mm build
-#gantry_corners:
-#   -60,-10
-#   360,370
-##  Probe points
-#points:
-#   50,25
-#   50,225
-#   250,225
-#   250,25
+##--------------------------------------------------------------------
+## Uncomment below for 250mm build
+z_positions:
+    -50, 18
+    125, 298
+    300, 18
+points:
+    30, 5
+    125, 195
+    220, 5
 
-##  Gantry Corners for 350mm Build
-##  Uncomment for 350mm build
-#gantry_corners:
-#   -60,-10
-#   410,420
-##  Probe points
+## Uncomment below for 300mm build
+#z_positions:
+#   -50, 18
+#   150, 348
+#   350, 18
 #points:
-#   50,25
-#   50,275
-#   300,275
-#   300,25
+#   30, 5
+#   150, 245
+#   270, 5
 
-#--------------------------------------------------------------------
-speed: 100
+## Uncomment below for 350mm build
+#z_positions:
+#   -50, 18
+#   175, 398
+#   400, 18
+#points:
+#   30, 5
+#   175, 295
+#   320, 5
+
+
+##--------------------------------------------------------------------
+
+speed: 200
 horizontal_move_z: 10
 retries: 5
 retry_tolerance: 0.0075
-max_adjust: 10
 
 ########################################
 # EXP1 / EXP2 (display) pins

--- a/Firmware/Octopus/Trident_Octopus_Config.cfg
+++ b/Firmware/Octopus/Trident_Octopus_Config.cfg
@@ -12,6 +12,7 @@
 ## *** THINGS TO CHANGE/CHECK: ***
 ## MCU paths                            [mcu] section
 ## Thermistor types                     [extruder] and [heater_bed] sections - See 'sensor types' list at end of file
+## Leadscrew Rotation Distance          [stepper_z], [stepper_z1], [stepper_z2]
 ## Z Endstop Switch location            [safe_z_home] section
 ## Z Endstop Switch  offset for Z0      [stepper_z] section
 ## PID tune                             [extruder] and [heater_bed] sections
@@ -121,16 +122,15 @@ stealthchop_threshold: 0
 #   Z Stepper Settings
 #####################################################################
 
-## Z0 Stepper - Front Left
+##  Z0 Stepper - Front Left
 ##  Connected to MOTOR_2
 ##  Endstop connected to DIAG_2
 [stepper_z]
 step_pin: PF11
 dir_pin: PG3
 enable_pin: !PG5
-##T8x4 Lead Screws.  One rotation moves the bed 4mm 
-##Change according to integrated steppers purchased
-rotation_distance: 4
+# Rotation Distance for TR8x8 = 8, TR8x4 = 4, TR8x2 = 2
+# rotation_distance: 8    
 microsteps: 32
 endstop_pin: PG10
 ##  Z-position of nozzle (in mm) to z-endstop trigger point relative to print surface (Z0)
@@ -161,10 +161,8 @@ stealthchop_threshold: 0
 step_pin: PG4
 dir_pin: PC1
 enable_pin: !PA0
-##T8x4 Lead Screws.  One rotation moves the bed 4mm 
-##Change according to integrated steppers purchased
-rotation_distance: 4
-microsteps: 32
+# Rotation Distance for TR8x8 = 8, TR8x4 = 4, TR8x2 = 2
+# rotation_distance: 8  
 microsteps: 32
 
 ##  Make sure to update below for your relevant driver (2208 or 2209)
@@ -182,10 +180,8 @@ stealthchop_threshold: 0
 step_pin: PF9
 dir_pin: !PF10
 enable_pin: !PG2
-##T8x4 Lead Screws.  One rotation moves the bed 4mm 
-##Change according to integrated steppers purchased
-rotation_distance: 4
-microsteps: 32
+# Rotation Distance for TR8x8 = 8, TR8x4 = 4, TR8x2 = 2
+# rotation_distance: 8  
 microsteps: 32
 
 ##  Make sure to update below for your relevant driver (2208 or 2209)
@@ -223,7 +219,8 @@ full_steps_per_rotation: 200    #200 for 1.8 degree, 400 for 0.9 degree
 nozzle_diameter: 0.400
 filament_diameter: 1.75
 heater_pin: PA2
-##  Validate the following thermistor type to make sure it is correct (see bottom of file for additional options)
+##  Validate the following thermistor type to make sure it is correct
+##  See https://www.klipper3d.org/Config_Reference.html#common-thermistors for additional options
 # sensor_type: ATC Semitec 104GT-2
 sensor_pin: PF4
 min_temp: 10
@@ -258,8 +255,9 @@ stealthchop_threshold: 0
 ##  SSR Pin - HE1
 ##  Thermistor - TB
 heater_pin: PA3
-##  Validate the following thermistor type to make sure it is correct (see bottom of file for additional options)
-# sensor_type: NTC 100K MGB18-104F39050L32
+##  Validate the following thermistor type to make sure it is correct
+##  See https://www.klipper3d.org/Config_Reference.html#common-thermistors for additional options
+# sensor_type: Generic 3950
 sensor_pin: PF3
 ##  Adjust Max Power so your heater doesn't warp your bed. Rule of thumb is 0.4 watts / cm^2 .
 max_power: 0.6
@@ -541,12 +539,3 @@ gcode:
     
     BED_MESH_CLEAR
     RESTORE_GCODE_STATE NAME=STATE_PRINT_END
-    
-##  Thermistor Types
-##   "EPCOS 100K B57560G104F"
-##   "ATC Semitec 104GT-2"
-##   "NTC 100K beta 3950"
-##   "Honeywell 100K 135-104LAG-J01"
-##   "NTC 100K MGB18-104F39050L32" (Keenovo Heater Pad)
-##   "AD595"
-##   "PT100 INA826"


### PR DESCRIPTION
This config matches the wiring diagram for the v2 in the voron docs, which will allow us to re-use it and save some work. 