### PR TITLE
Add G90 to PRINT_START macro

### DIFF
--- a/Firmware/Octopus/Trident_Octopus_Config.cfg
+++ b/Firmware/Octopus/Trident_Octopus_Config.cfg
@@ -486,6 +486,7 @@ gcode:
     G28
     Z_TILT_ADJUST
     G28
+    G90                            ; absolute positioning
 
     ##  Uncomment for for your size printer:
     #--------------------------------------------------------------------

--- a/Firmware/Voron_Trident_SKR14_EXPMOT.cfg
+++ b/Firmware/Voron_Trident_SKR14_EXPMOT.cfg
@@ -468,7 +468,8 @@ gcode:
     G28 Y0 X0 Z0
     Z_TILT_ADJUST
     G28 Y0 X0 Z0
-    
+    G90                            ; absolute positioning
+
     ##Purge Line Gcode
     #G92 E0;
     #G90

--- a/Firmware/Voron_Trident_SKR_1.3.cfg
+++ b/Firmware/Voron_Trident_SKR_1.3.cfg
@@ -539,7 +539,8 @@ gcode:
     G28 Y0 X0 Z0
     Z_TILT_ADJUST
     G28 Y0 X0 Z0
-    
+    G90                            ; absolute positioning
+
     ##Purge Line Gcode
     #G92 E0;
     #G90


### PR DESCRIPTION
Added G90 to PRINT_START macro to prevent errors, when printer is in relative mode.