### PR TITLE
Remove default sensor_types, convert tabs to spaces

### DIFF
--- a/Firmware/Octopus/Trident_Octopus_Config.cfg
+++ b/Firmware/Octopus/Trident_Octopus_Config.cfg
@@ -215,7 +215,7 @@ filament_diameter: 1.75
 heater_pin: PA2
 ## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
 ## Use "Generic 3950" for NTC 100k 3950 thermistors
-sensor_type:
+#sensor_type:
 sensor_pin: PF4
 min_temp: 10
 max_temp: 270
@@ -250,7 +250,7 @@ stealthchop_threshold: 0
 heater_pin: PA3
 ## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
 ## Use "Generic 3950" for Keenovo heaters
-sensor_type:
+#sensor_type:
 sensor_pin: PF3
 ##  Adjust Max Power so your heater doesn't warp your bed. Rule of thumb is 0.4 watts / cm^2 .
 max_power: 0.6

--- a/Firmware/Octopus/Trident_Octopus_Config.cfg
+++ b/Firmware/Octopus/Trident_Octopus_Config.cfg
@@ -11,7 +11,7 @@
 
 ## *** THINGS TO CHANGE/CHECK: ***
 ## MCU paths                            [mcu] section
-## Thermistor types                     [extruder] and [heater_bed] sections
+## Thermistor types                     [extruder] and [heater_bed] sections - See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types
 ## Leadscrew Rotation Distance          [stepper_z], [stepper_z1], [stepper_z2]
 ## Z Endstop Switch location            [safe_z_home] section
 ## Z Endstop Switch  offset for Z0      [stepper_z] section
@@ -213,9 +213,9 @@ full_steps_per_rotation: 200    #200 for 1.8 degree, 400 for 0.9 degree
 nozzle_diameter: 0.400
 filament_diameter: 1.75
 heater_pin: PA2
-##  Validate the following thermistor type to make sure it is correct
-##  See https://www.klipper3d.org/Config_Reference.html#common-thermistors for additional options
-#sensor_type: ATC Semitec 104GT-2
+## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
+## Use "Generic 3950" for NTC 100k 3950 thermistors
+sensor_type:
 sensor_pin: PF4
 min_temp: 10
 max_temp: 270
@@ -248,9 +248,9 @@ stealthchop_threshold: 0
 ##  SSR Pin - HE1
 ##  Thermistor - TB
 heater_pin: PA3
-##  Validate the following thermistor type to make sure it is correct
-##  See https://www.klipper3d.org/Config_Reference.html#common-thermistors for additional options
-#sensor_type: Generic 3950
+## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
+## Use "Generic 3950" for Keenovo heaters
+sensor_type:
 sensor_pin: PF3
 ##  Adjust Max Power so your heater doesn't warp your bed. Rule of thumb is 0.4 watts / cm^2 .
 max_power: 0.6

--- a/Firmware/Voron_Trident_SKR14_EXPMOT.cfg
+++ b/Firmware/Voron_Trident_SKR14_EXPMOT.cfg
@@ -1,7 +1,7 @@
 ## *** THINGS TO CHANGE/CHECK: ***
-## MCU paths                         	 [mcu] section
+## MCU paths                             [mcu] section
 ## Thermistor types                      [extruder] and [heater_bed] sections - See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types
-## Z Endstop Switch location       		 [homing_override] section
+## Z Endstop Switch location             [homing_override] section
 ## Z Endstop Switch  offset for Z0       [stepper_z] section
 ## PID tune                              [extruder] and [heater_bed] sections
 ## Fine tune E steps                     [extruder] section
@@ -48,7 +48,7 @@
 ## TB  (Bed Temp)     0.25
 ## FAN0               2.3
 ## SERVO              2.0
-## PROBE			  0.10
+## PROBE              0.10
 
 ## Expander
 ## M1_STEP_PIN         0.18    
@@ -86,7 +86,7 @@ max_z_accel: 100
 square_corner_velocity: 5.0  
 
 #####################################################################
-# 	X/Y Stepper Settings
+#   X/Y Stepper Settings
 #####################################################################\
 
 ######
@@ -106,15 +106,15 @@ rotation_distance: 40
 full_steps_per_rotation: 400
 endstop_pin: !P1.29
 position_min: 0
-##	Uncomment below for 250mm build
+##  Uncomment below for 250mm build
 #position_endstop: 250
 #position_max: 250
 
-##	Uncomment for 300mm build
+##  Uncomment for 300mm build
 #position_endstop: 300
 #position_max: 300
 
-##	Uncomment for 350mm build
+##  Uncomment for 350mm build
 #position_endstop: 350
 #position_max: 350
 
@@ -146,15 +146,15 @@ rotation_distance: 40
 full_steps_per_rotation: 400
 endstop_pin: !P1.28
 ##--------------------------------------------------------------------
-##	Uncomment for 250mm build
+##  Uncomment for 250mm build
 #position_endstop: 250
 #position_max: 250
 
-##	Uncomment for 300mm build
+##  Uncomment for 300mm build
 #position_endstop: 300
 #position_max: 300
 
-##	Uncomment for 350mm build
+##  Uncomment for 350mm build
 #position_endstop: 350
 #position_max: 350
 ##--------------------------------------------------------------------
@@ -169,7 +169,7 @@ hold_current: 0.750
 
 
 #####################################################################
-# 	Z Stepper Settings
+#   Z Stepper Settings
 #####################################################################
 
 ######
@@ -277,7 +277,7 @@ pressure_advance_smooth_time: 0.040
 heater_pin: P2.7
 ## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
 ## Use "Generic 3950" for NTC 100k 3950 thermistors
-sensor_type:
+#sensor_type:
 sensor_pin: P0.24
 min_extrude_temp: 180
 min_temp: 0
@@ -288,7 +288,7 @@ pid_ki = 1.304
 pid_kd = 131.721
 #Set appropriate once tuning your printer
 #pressure_advance: .05
-##	Default is 0.040, leave stock
+##  Default is 0.040, leave stock
 pressure_advance_smooth_time: 0.040
 
 [tmc2209 extruder]
@@ -299,15 +299,15 @@ sense_resistor: 0.110
 stealthchop_threshold: 0
 
 #####################################################################
-# 	Bed Heater
+#   Bed Heater
 #####################################################################   
 [heater_bed]
 heater_pin: P2.5
 ## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
 ## Use "Generic 3950" for Keenovo heaters
-sensor_type:
+#sensor_type:
 sensor_pin: P0.25
-##	Adjust Max Power so your heater doesn't warp your bed
+##  Adjust Max Power so your heater doesn't warp your bed
 max_power: 0.6
 min_temp: 0
 max_temp: 120
@@ -317,7 +317,7 @@ pid_ki: 2.347
 pid_kd: 363.769
 
 #####################################################################
-# 	Probe
+#   Probe
 #####################################################################
 
 ######
@@ -338,7 +338,7 @@ samples_tolerance: 0.05
 samples_tolerance_retries: 3
 
 #####################################################################
-# 	Fan Control
+#   Fan Control
 #####################################################################
 
 ######
@@ -364,7 +364,7 @@ heater_temp: 50.0
 ## may be sought for MOSFET controlled ports.
 
 #####################################################################
-# 	Homing and Gantry Adjustment Routines
+#   Homing and Gantry Adjustment Routines
 #####################################################################
 
 [idle_timeout]
@@ -377,74 +377,74 @@ gcode:
    G90
    G0 Z5 F600
    G28 X Y
-   ##	XY Location of the Z Endstop Switch
-   ##	Update X and Y to your values (such as X157, Y305) after going through
-   ##	Z Endstop Pin Location Definition step.
+   ##   XY Location of the Z Endstop Switch
+   ##   Update X and Y to your values (such as X157, Y305) after going through
+   ##   Z Endstop Pin Location Definition step.
    G0 X-10 Y-10 F3600 
    
    G28 Z
    G0 Z10 F1800
 
       
-   	##	Uncomment for for your size printer:
-   	## 	Rough measurement is the middle of your bed.
+    ##  Uncomment for for your size printer:
+    ##  Rough measurement is the middle of your bed.
 #--------------------------------------------------------------------
-   	##	Uncomment for 250mm build
-   	#G0 X125 Y125 Z30 F3600
+    ##  Uncomment for 250mm build
+    #G0 X125 Y125 Z30 F3600
    
-	##	Uncomment for 300 build
-   	#G0 X150 Y150 Z30 F3600
+    ##  Uncomment for 300 build
+    #G0 X150 Y150 Z30 F3600
 
-    ##	Uncomment for 350 build
-   	#G0 X175 Y175 Z30 F3600
+    ##  Uncomment for 350 build
+    #G0 X175 Y175 Z30 F3600
 #--------------------------------------------------------------------
 
 #####################################################################
-# 	Displays
+#   Displays
 #####################################################################
 
 #Using the EXP-MOT Expander uses up standard Mini FYSETC Capable Display
 #Ports.  Other solutions must be procured.
 
 #####################################################################
-# 	Macros
+#   Macros
 #####################################################################
 
 [z_tilt]
-##	Use Z_TILT_ADJUST to level the bed .
-##	z_positions: Location of toolhead
+##  Use Z_TILT_ADJUST to level the bed .
+##  z_positions: Location of toolhead
 
 ##--------------------------------------------------------------------
 ## Uncomment below for 250mm build
 #z_positions:
-#	-50, 18
-#	125, 298
-#	300, 18
+#   -50, 18
+#   125, 298
+#   300, 18
 #points:
-#	30, 5
-#	125, 195
-#	220, 5
+#   30, 5
+#   125, 195
+#   220, 5
 
 ## Uncomment below for 300mm build
 #z_positions:
-#	-50, 18
-#	150, 348
-#	350, 18
+#   -50, 18
+#   150, 348
+#   350, 18
 
 #points:
-#	30, 5
-#	150, 245
-#	270, 5
+#   30, 5
+#   150, 245
+#   270, 5
 
 ## Uncomment below for 350mm build
 #z_positions:
-#	-50, 18
-#	175, 398
-#	400, 18
+#   -50, 18
+#   175, 398
+#   400, 18
 #points:
-#	30, 5
-#	175, 295
-#	320, 5
+#   30, 5
+#   175, 295
+#   320, 5
 
 
 ##--------------------------------------------------------------------
@@ -521,4 +521,4 @@ gcode:
     G90                              ; absolute positioning
     G0 X{max_x / 2} Y{max_y} F3600   ; park nozzle at rear
     M117 Finished!
-	
+    

--- a/Firmware/Voron_Trident_SKR14_EXPMOT.cfg
+++ b/Firmware/Voron_Trident_SKR14_EXPMOT.cfg
@@ -1,8 +1,8 @@
 ## *** THINGS TO CHANGE/CHECK: ***
-## MCU paths                         	[mcu] section
-## Thermistor types                      [extruder] and [heater_bed] sections - See 'sensor types' list at end of file
-## Z Endstop Switch location       		[homing_override] section
-## Z Endstop Switch  offset for Z0  		[stepper_z] section
+## MCU paths                         	 [mcu] section
+## Thermistor types                      [extruder] and [heater_bed] sections - See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types
+## Z Endstop Switch location       		 [homing_override] section
+## Z Endstop Switch  offset for Z0       [stepper_z] section
 ## PID tune                              [extruder] and [heater_bed] sections
 ## Fine tune E steps                     [extruder] section
 
@@ -65,15 +65,6 @@
 ## M3_DIR_PIN          0.15    
 ## M3_ENABLE_PIN       1.22    
 ## M3_UART             0.28
-
-## Thermistor Types
-##   "EPCOS 100K B57560G104F"
-##   "ATC Semitec 104GT-2"
-##   "NTC 100K beta 3950"
-##   "Honeywell 100K 135-104LAG-J01"
-##   "NTC 100K MGB18-104F39050L32"
-##   "AD595"
-##   "PT100 INA826"
 ##===================================================================.
 
 [virtual_sdcard]
@@ -284,8 +275,9 @@ filament_diameter: 1.750
 pressure_advance: 0.67
 pressure_advance_smooth_time: 0.040
 heater_pin: P2.7
-##	Validate the following thermistor type to make sure it is correct
-sensor_type: NTC 100K beta 3950
+## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
+## Use "Generic 3950" for NTC 100k 3950 thermistors
+sensor_type:
 sensor_pin: P0.24
 min_extrude_temp: 180
 min_temp: 0
@@ -311,8 +303,9 @@ stealthchop_threshold: 0
 #####################################################################   
 [heater_bed]
 heater_pin: P2.5
-##  Choose the correct thermistor for your heater
-sensor_type: EPCOS 100K B57560G104F
+## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
+## Use "Generic 3950" for Keenovo heaters
+sensor_type:
 sensor_pin: P0.25
 ##	Adjust Max Power so your heater doesn't warp your bed
 max_power: 0.6

--- a/Firmware/Voron_Trident_SKR14_EXPMOT.cfg
+++ b/Firmware/Voron_Trident_SKR14_EXPMOT.cfg
@@ -521,4 +521,3 @@ gcode:
     G90                              ; absolute positioning
     G0 X{max_x / 2} Y{max_y} F3600   ; park nozzle at rear
     M117 Finished!
-    

--- a/Firmware/Voron_Trident_SKR_1.3.cfg
+++ b/Firmware/Voron_Trident_SKR_1.3.cfg
@@ -1,7 +1,7 @@
 ## *** THINGS TO CHANGE/CHECK: ***
-## MCU paths                         	 [mcu] section
+## MCU paths                             [mcu] section
 ## Thermistor types                      [extruder] and [heater_bed] sections - See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types
-## Z Endstop Switch location       		 [homing_override] section
+## Z Endstop Switch location             [homing_override] section
 ## Z Endstop Switch  offset for Z0       [stepper_z] section
 ## PID tune                              [extruder] and [heater_bed] sections
 ## Fine tune E steps                     [extruder] section
@@ -81,7 +81,7 @@ serial: /dev/serial/by-id/usb-Klipper_lpc1768_XXXXXXXXXXXXXXXXXXXXX
 
 
 #####################################################################
-# 	X/Y Stepper Settings
+#   X/Y Stepper Settings
 #####################################################################
 
 ######
@@ -106,15 +106,15 @@ full_steps_per_rotation: 200
 endstop_pin: xye:P1.28
 position_min: 0
 
-##	Uncomment below for 250mm build
+##  Uncomment below for 250mm build
 #position_endstop: 250
 #position_max: 250
 
-##	Uncomment for 300mm build
+##  Uncomment for 300mm build
 #position_endstop: 300
 #position_max: 300
 
-##	Uncomment for 350mm build
+##  Uncomment for 350mm build
 #position_endstop: 350
 #position_max: 350
 
@@ -123,7 +123,7 @@ homing_speed: 25   #Max 100
 homing_retract_dist: 5
 homing_positive_dir: true
 
-##	Make sure to update below for your relevant driver (2208 or 2209)
+##  Make sure to update below for your relevant driver (2208 or 2209)
 [tmc2209 stepper_x]
 uart_pin: xye:P1.17
 interpolate: True
@@ -153,15 +153,15 @@ microsteps: 16
 endstop_pin: xye:P1.26
 position_min: 0
 ##--------------------------------------------------------------------
-##	Uncomment for 250mm build
+##  Uncomment for 250mm build
 #position_endstop: 250
 #position_max: 250
 
-##	Uncomment for 300mm build
+##  Uncomment for 300mm build
 #position_endstop: 300
 #position_max: 300
 
-##	Uncomment for 350mm build
+##  Uncomment for 350mm build
 #position_endstop: 350
 #position_max: 350
 ##--------------------------------------------------------------------
@@ -169,7 +169,7 @@ homing_speed: 25  #Max 100
 homing_retract_dist: 5
 homing_positive_dir: true
 
-##	Make sure to update below for your relevant driver
+##  Make sure to update below for your relevant driver
 [tmc2209 stepper_y]
 uart_pin: xye:P1.15
 interpolate: True
@@ -179,7 +179,7 @@ sense_resistor: 0.110
 stealthchop_threshold: 0
 
 #####################################################################
-# 	Z Stepper Settings
+#   Z Stepper Settings
 #####################################################################
 
 ######
@@ -216,7 +216,7 @@ homing_speed: 8 # Leadscrews are slower than 2.4, 10 is a recommended max.
 second_homing_speed: 3.0
 homing_retract_dist: 3.0
 
-##	Make sure to update below for your relevant driver (2208 or 2209)
+##  Make sure to update below for your relevant driver (2208 or 2209)
 [tmc2209 stepper_z]
 uart_pin: P1.1
 interpolate: true
@@ -245,7 +245,7 @@ full_steps_per_rotation: 200
 microsteps: 16
 
 
-##	Make sure to update below for your relevant driver (2208 or 2209)
+##  Make sure to update below for your relevant driver (2208 or 2209)
 [tmc2209 stepper_z1]
 uart_pin: P1.10
 interpolate: true
@@ -254,8 +254,8 @@ hold_current: 0.6
 sense_resistor: 0.110
 stealthchop_threshold: 0
 
-##	Main MCU - In X Position
-##	Z2 Stepper - Front Right
+##  Main MCU - In X Position
+##  Z2 Stepper - Front Right
 
 ######
 #Z Stepper - Front Right
@@ -276,7 +276,7 @@ rotation_distance: 4
 full_steps_per_rotation: 200
 microsteps: 16
 
-##	Make sure to update below for your relevant driver (2208 or 2209)
+##  Make sure to update below for your relevant driver (2208 or 2209)
 [tmc2209 stepper_z2]
 uart_pin: P1.17
 interpolate: True
@@ -309,7 +309,7 @@ filament_diameter: 1.75
 heater_pin: xye:P2.7
 ## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
 ## Use "Generic 3950" for NTC 100k 3950 thermistors
-sensor_type:
+#sensor_type:
 sensor_pin: xye:P0.24
 min_temp: 10
 max_temp: 270
@@ -321,11 +321,11 @@ pid_ki = 1.304
 pid_kd = 131.721
 #Set appropriate once tuning your printer
 #pressure_advance: .05
-##	Default is 0.040, leave stock
+##  Default is 0.040, leave stock
 pressure_advance_smooth_time: 0.040
 max_extrude_only_distance: 200.0
 
-##	Make sure to update below for your relevant driver
+##  Make sure to update below for your relevant driver
 [tmc2209 extruder]
 uart_pin: xye:P1.8
 run_current: 0.5
@@ -334,7 +334,7 @@ sense_resistor: 0.110
 stealthchop_threshold: 0
 
 #####################################################################
-# 	Bed Heater
+#   Bed Heater
 #####################################################################
 
 ######
@@ -344,9 +344,9 @@ stealthchop_threshold: 0
 heater_pin: P2.4
 ## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
 ## Use "Generic 3950" for Keenovo heaters
-sensor_type:
+#sensor_type:
 sensor_pin: P0.23
-##	Adjust Max Power so your heater doesn't warp your bed
+##  Adjust Max Power so your heater doesn't warp your bed
 max_power: 0.6
 min_temp: 0
 max_temp: 120
@@ -356,7 +356,7 @@ pid_ki: 2.347
 pid_kd: 363.769
 
 #####################################################################
-# 	Probe
+#   Probe
 #####################################################################
 
 ######
@@ -377,27 +377,27 @@ samples_tolerance: 0.006
 samples_tolerance_retries: 3
 
 #####################################################################
-# 	Fan Control
+#   Fan Control
 #####################################################################
 
 [heater_fan extruder_fan]
 pin: xye:P2.4   # "FAN1"
 heater: extruder
 heater_temp: 50.0
-##	If you are experiencing back flow, you can reduce fan_speed
+##  If you are experiencing back flow, you can reduce fan_speed
 #fan_speed: 1.0
 
 ##Part Cooling Fan
 [fan]
 pin: xye:P2.3  # "FAN0"
 cycle_time: .08
-##	Depending on your fan, you may need to increase this value
-##	if your fan will not start. Can change cycle_time (increase)
-##	if your fan is not able to slow down effectively
+##  Depending on your fan, you may need to increase this value
+##  if your fan will not start. Can change cycle_time (increase)
+##  if your fan is not able to slow down effectively
 kick_start_time: .25
 
 #[heater_fan exhaust_fan]
-##	Exhaust Fan - Bed Connector (Optional)
+##  Exhaust Fan - Bed Connector (Optional)
 #pin: P2.5
 #max_power: 1.0
 #shutdown_speed: 0.0
@@ -407,7 +407,7 @@ kick_start_time: .25
 #fan_speed: 1.0
 
 #####################################################################
-# 	Homing and Gantry Adjustment Routines
+#   Homing and Gantry Adjustment Routines
 #####################################################################
 
 [idle_timeout]
@@ -420,33 +420,33 @@ gcode:
    G90
    G0 Z5 F600
    G28 X Y
-   ##	XY Location of the Z Endstop Switch
-   ##	Update X and Y to your values (such as X157, Y305) after going through
-   ##	Z Endstop Pin Location Definition step.
+   ##   XY Location of the Z Endstop Switch
+   ##   Update X and Y to your values (such as X157, Y305) after going through
+   ##   Z Endstop Pin Location Definition step.
    G0 X-10 Y-10 F3600 
    
    G28 Z
    G0 Z10 F1800
    
-   	##	Uncomment for for your size printer:
-   	## 	Rough measurement is the middle of your bed.
+    ##  Uncomment for for your size printer:
+    ##  Rough measurement is the middle of your bed.
 #--------------------------------------------------------------------
-   	##	Uncomment for 250mm build
-   	#G0 X125 Y125 Z30 F3600
+    ##  Uncomment for 250mm build
+    #G0 X125 Y125 Z30 F3600
    
-	##	Uncomment for 300 build
-   	#G0 X150 Y150 Z30 F3600
+    ##  Uncomment for 300 build
+    #G0 X150 Y150 Z30 F3600
 
-    ##	Uncomment for 350 build
-   	#G0 X175 Y175 Z30 F3600
+    ##  Uncomment for 350 build
+    #G0 X175 Y175 Z30 F3600
 #--------------------------------------------------------------------
 
 #####################################################################
-# 	Displays
+#   Displays
 #####################################################################
 
 
-## 	For the mini12864 Display, the [display] and [neopixel] must be uncommented
+##  For the mini12864 Display, the [display] and [neopixel] must be uncommented
 # mini12864 LCD Display
 # connected to exp1/2 on Z(main) MCU
 #[display]
@@ -458,7 +458,7 @@ gcode:
 #contrast: 63
 
 #[neopixel fysetc_mini12864]
-##	To control Neopixel RGB in mini12864 display
+##  To control Neopixel RGB in mini12864 display
 ## Remember with these ones, you'll need to remove the connector header on the LCD for EXT1 + 2
 ## (it slides off) and reverse it for it to work on your SKR (1.3 and 1.4) board
 #pin: P1.21
@@ -468,54 +468,54 @@ gcode:
 #initial_BLUE: 1
 #color_order: RGB
 
-##	Set RGB values on boot up for each Neopixel. 
-##	Index 1 = display, Index 2 and 3 = Knob
+##  Set RGB values on boot up for each Neopixel. 
+##  Index 1 = display, Index 2 and 3 = Knob
 #[delayed_gcode setdisplayneopixel]
 #initial_duration: 1
 #gcode:
-#        SET_LED LED=fysetc_mini12864 RED=1 GREEN=1 BLUE=1 INDEX=1 TRANSMIT=0	# Backlit Screen colour
-#        SET_LED LED=fysetc_mini12864 RED=1 GREEN=0 BLUE=0 INDEX=2 TRANSMIT=0	# Top left Knob colour
-#        SET_LED LED=fysetc_mini12864 RED=1 GREEN=0 BLUE=0 INDEX=3				# Bottom right knob colour
+#        SET_LED LED=fysetc_mini12864 RED=1 GREEN=1 BLUE=1 INDEX=1 TRANSMIT=0   # Backlit Screen colour
+#        SET_LED LED=fysetc_mini12864 RED=1 GREEN=0 BLUE=0 INDEX=2 TRANSMIT=0   # Top left Knob colour
+#        SET_LED LED=fysetc_mini12864 RED=1 GREEN=0 BLUE=0 INDEX=3              # Bottom right knob colour
 
 #--------------------------------------------------------------------
 
 #####################################################################
-# 	Macros
+#   Macros
 #####################################################################
 [z_tilt]
-##	Use Z_TILT_ADJUST to level the bed .
-##	z_positions: Location of toolhead
+##  Use Z_TILT_ADJUST to level the bed .
+##  z_positions: Location of toolhead
 
 ##--------------------------------------------------------------------
 ## Uncomment below for 250mm build
 #z_positions:
-#	-50, 18
-#	125, 298
-#	300, 18
+#   -50, 18
+#   125, 298
+#   300, 18
 #points:
-#	30, 5
-#	125, 195
-#	220, 5
+#   30, 5
+#   125, 195
+#   220, 5
 
 ## Uncomment below for 300mm build
 #z_positions:
-#	-50, 18
-#	150, 348
-#	350, 18
+#   -50, 18
+#   150, 348
+#   350, 18
 #points:
-#	30, 5
-#	150, 245
-#	270, 5
+#   30, 5
+#   150, 245
+#   270, 5
 
 ## Uncomment below for 350mm build
 #z_positions:
-#	-50, 18
-#	175, 398
-#	400, 18
+#   -50, 18
+#   175, 398
+#   400, 18
 #points:
-#	30, 5
-#	175, 295
-#	320, 5
+#   30, 5
+#   175, 295
+#   320, 5
 
 
 ##--------------------------------------------------------------------

--- a/Firmware/Voron_Trident_SKR_1.3.cfg
+++ b/Firmware/Voron_Trident_SKR_1.3.cfg
@@ -1,8 +1,8 @@
 ## *** THINGS TO CHANGE/CHECK: ***
-## MCU paths                         	[mcu] section
-## Thermistor types                      [extruder] and [heater_bed] sections - See 'sensor types' list at end of file
-## Z Endstop Switch location       		[homing_override] section
-## Z Endstop Switch  offset for Z0  		[stepper_z] section
+## MCU paths                         	 [mcu] section
+## Thermistor types                      [extruder] and [heater_bed] sections - See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types
+## Z Endstop Switch location       		 [homing_override] section
+## Z Endstop Switch  offset for Z0       [stepper_z] section
 ## PID tune                              [extruder] and [heater_bed] sections
 ## Fine tune E steps                     [extruder] section
 
@@ -51,15 +51,6 @@
 ## TB  (Bed Temp)     0.23
 ## FAN                2.3
 ## SERVO              2.0
-
-## Thermistor Types
-##   "EPCOS 100K B57560G104F"
-##   "ATC Semitec 104GT-2"
-##   "NTC 100K beta 3950"
-##   "Honeywell 100K 135-104LAG-J01"
-##   "NTC 100K MGB18-104F39050L32"
-##   "AD595"
-##   "PT100 INA826"
 ##===================================================================
 
 #Mainsail support
@@ -316,8 +307,9 @@ full_steps_per_rotation: 200
 nozzle_diameter: 0.400
 filament_diameter: 1.75
 heater_pin: xye:P2.7
-##	Validate the following thermistor type to make sure it is correct
-sensor_type: NTC 100K beta 3950
+## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
+## Use "Generic 3950" for NTC 100k 3950 thermistors
+sensor_type:
 sensor_pin: xye:P0.24
 min_temp: 10
 max_temp: 270
@@ -350,8 +342,9 @@ stealthchop_threshold: 0
 ###############
 [heater_bed]
 heater_pin: P2.4
-##  Choose the correct thermistor for your heater
-sensor_type: NTC 100K MGB18-104F39050L32
+## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
+## Use "Generic 3950" for Keenovo heaters
+sensor_type:
 sensor_pin: P0.23
 ##	Adjust Max Power so your heater doesn't warp your bed
 max_power: 0.6


### PR DESCRIPTION
- Remove default `sensor_type:` values to ensure that users are verifying their thermistors. Many users are just using the default values without actually checking.
- Add comments linking to Klipper thermistor list (so always up-to-date)
- Remove thermistor list at bottom of config files (if it exists - better to use the always up-to-date Klipper link)
- Hint at using "Generic 3950" for NTC 100k 3950, and also for Keenovo heaters
- Remove custom 3950 definition (if exists) - no longer necessary, Klipper thermistor accuracy bug has been fixed, and any new builders will be pulling a new version of Klipper.