### PR TITLE
Remove [SAVE|RESTORE]_GCODE_STATE from PRINT_END macro

### DIFF
--- a/Firmware/M8P/Trident_M8P_config.cfg
+++ b/Firmware/M8P/Trident_M8P_config.cfg
@@ -502,6 +502,8 @@ gcode:
 [gcode_macro PRINT_END]
 #   Use PRINT_END for the slicer ending script - please customise for your slicer of choice
 gcode:
+    SAVE_GCODE_STATE NAME=STATE_PRINT_END
+
     M400                           ; wait for buffer to clear
     G92 E0                         ; zero the extruder
     G1 E-10.0 F3600                ; retract filament
@@ -514,4 +516,9 @@ gcode:
     G0  X125 Y250 F3600            ; park nozzle at rear
     BED_MESH_CLEAR
     
-
+    # The purpose of the SAVE_GCODE_STATE/RESTORE_GCODE_STATE
+    # command pair is to restore the printer's coordinate system
+    # and speed settings since the commands above change them.
+    # However, to prevent any accidental, unintentional toolhead
+    # moves when restoring the state, explicitly set MOVE=0.
+    RESTORE_GCODE_STATE NAME=STATE_PRINT_END MOVE=0

--- a/Firmware/Octopus/Trident_Octopus_Config.cfg
+++ b/Firmware/Octopus/Trident_Octopus_Config.cfg
@@ -514,7 +514,7 @@ gcode:
     {% set z_safe = [th.position.z + 2, th.axis_maximum.z]|min %}
     
     SAVE_GCODE_STATE NAME=STATE_PRINT_END
-    
+
     M400                           ; wait for buffer to clear
     G92 E0                         ; zero the extruder
     G1 E-2.0 F3600                 ; retract filament
@@ -527,4 +527,10 @@ gcode:
     M107                                     ; turn off fan
     
     BED_MESH_CLEAR
-    RESTORE_GCODE_STATE NAME=STATE_PRINT_END
+
+    # The purpose of the SAVE_GCODE_STATE/RESTORE_GCODE_STATE
+    # command pair is to restore the printer's coordinate system
+    # and speed settings since the commands above change them.
+    # However, to prevent any accidental, unintentional toolhead
+    # moves when restoring the state, explicitly set MOVE=0.
+    RESTORE_GCODE_STATE NAME=STATE_PRINT_END MOVE=0

--- a/Firmware/Voron_Trident_SKR14_EXPMOT.cfg
+++ b/Firmware/Voron_Trident_SKR14_EXPMOT.cfg
@@ -513,6 +513,8 @@ gcode:
     {% endif %}
     
     #  Commence PRINT_END
+    SAVE_GCODE_STATE NAME=STATE_PRINT_END
+
     M400                             ; wait for buffer to clear
     G92 E0                           ; zero the extruder
     G1 E-4.0 F3600                   ; retract
@@ -525,4 +527,12 @@ gcode:
     M106 S0                          ; turn off fan
     G90                              ; absolute positioning
     G0 X{max_x / 2} Y{max_y} F3600   ; park nozzle at rear
+
+    # The purpose of the SAVE_GCODE_STATE/RESTORE_GCODE_STATE
+    # command pair is to restore the printer's coordinate system
+    # and speed settings since the commands above change them.
+    # However, to prevent any accidental, unintentional toolhead
+    # moves when restoring the state, explicitly set MOVE=0.
+    RESTORE_GCODE_STATE NAME=STATE_PRINT_END MOVE=0
+
     M117 Finished!

--- a/Firmware/Voron_Trident_SKR_1.3.cfg
+++ b/Firmware/Voron_Trident_SKR_1.3.cfg
@@ -586,6 +586,8 @@ gcode:
     {% endif %}
     
     #  Commence PRINT_END
+    SAVE_GCODE_STATE NAME=STATE_PRINT_END
+
     M400                             ; wait for buffer to clear
     G92 E0                           ; zero the extruder
     G1 E-4.0 F3600                   ; retract
@@ -598,4 +600,12 @@ gcode:
     M106 S0                          ; turn off fan
     G90                              ; absolute positioning
     G0 X{max_x / 2} Y{max_y} F3600   ; park nozzle at rear
+
+    # The purpose of the SAVE_GCODE_STATE/RESTORE_GCODE_STATE
+    # command pair is to restore the printer's coordinate system
+    # and speed settings since the commands above change them.
+    # However, to prevent any accidental, unintentional toolhead
+    # moves when restoring the state, explicitly set MOVE=0.
+    RESTORE_GCODE_STATE NAME=STATE_PRINT_END MOVE=0
+
     M117 Finished!


### PR DESCRIPTION
The sample configuration for some boards contain PRINT_END macros that include [SAVE|RESTORE]_GCODE_STATE command in them.

Unfortunately, those commands may have a negative effect in that the macro tries to perform some safety moves between them to move the toolhead away from the print. However, when the GCode state is restore, Klipper will move the toolhead to the last position before the GCode state is save. This will negate the safety moves and put the toolhead back where it was.

Fix this by removing the [SAVE|RESTORE]_GCODE_STATE command.