### PR TITLE
[BUGFIX] Use Z_TILT_ADJUST for bed leveling in G32 macro

### DIFF
--- a/Firmware/M8P/Trident_M8P_config.cfg
+++ b/Firmware/M8P/Trident_M8P_config.cfg
@@ -478,7 +478,7 @@ gcode:
 gcode:
     BED_MESH_CLEAR
     G28
-    QUAD_GANTRY_LEVEL
+    Z_TILT_ADJUST
     G28
     ##	Uncomment for for your size printer:
     #--------------------------------------------------------------------


### PR DESCRIPTION
The config is using QGL in the G32 macro even though it's for a Trident.