### PR TITLE
Bugfix: M8P example config: Correct motor 2 enable pin

### DIFF
--- a/Firmware/M8P/Trident_M8P_v2.0_config.cfg
+++ b/Firmware/M8P/Trident_M8P_v2.0_config.cfg
@@ -1,6 +1,6 @@
 # This file contains common pin mappings for the BIGTREETECH Manta M8P V2.0
 # To use this config, the firmware should be compiled for the
-# STM32G0B1 with a "8KiB bootloader" and USB communication.
+# STM32H723 with a "8KiB bootloader" and USB communication.
 
 # This config is currently only correct for V2.0 boards
 #
@@ -75,7 +75,7 @@ stealthchop_threshold: 0
 [stepper_y]
 step_pin: PE2
 dir_pin: PE1
-enable_pin: !PE0
+enable_pin: !PE4
 microsteps: 16
 rotation_distance: 40
 full_steps_per_rotation:200  #set to 400 for 0.9 degree stepper


### PR DESCRIPTION
As per PR to voron-2 repo- correct some minor issues in m8p v2 config example

Motor 2 enable pin

MCU name in header text