### PR TITLE
Trident m8p cfg fix

### DIFF
--- a/Firmware/M8P/Trident_M8P_v1.0_config.cfg
+++ b/Firmware/M8P/Trident_M8P_v1.0_config.cfg
@@ -137,7 +137,7 @@ homing_retract_dist: 3
 [tmc2209 stepper_z]
 uart_pin: PF9
 interpolate: true
-run_current: 0.8
+run_current: 0.6
 sense_resistor: 0.110
 stealthchop_threshold: 0
 

--- a/Firmware/M8P/Trident_M8P_v1.1_config.cfg
+++ b/Firmware/M8P/Trident_M8P_v1.1_config.cfg
@@ -137,7 +137,7 @@ homing_retract_dist: 3
 [tmc2209 stepper_z]
 uart_pin: PF9
 interpolate: true
-run_current: 0.8
+run_current: 0.6
 sense_resistor: 0.110
 stealthchop_threshold: 0
 

--- a/Firmware/M8P/Trident_M8P_v2.0_config.cfg
+++ b/Firmware/M8P/Trident_M8P_v2.0_config.cfg
@@ -137,7 +137,7 @@ homing_retract_dist: 3
 [tmc2209 stepper_z]
 uart_pin: PB9
 interpolate: true
-run_current: 0.8
+run_current: 0.6
 sense_resistor: 0.110
 stealthchop_threshold: 0
 


### PR DESCRIPTION
fixed the run current for Z0 motor to match the other 2 Z motors 

changed from 0.8 to 0.6 